### PR TITLE
Fix codelists

Removing empty columns, leading and trailing whitespace, extra quoting characters, and/or adding missing quoting characters, closing newline

### DIFF
--- a/codelists/preQualificationStatus.csv
+++ b/codelists/preQualificationStatus.csv
@@ -1,6 +1,6 @@
-Category,Code,Title_en,Description_en,Source
-,"planned","Planned","This pre-qualification has been proposed, but is not yet taking place.", 
-,"active","Active","A pre-qualification process is currently taking place.", 
-,"cancelled","Cancelled","The pre-qualification process has been cancelled.", 
-,"unsuccessful","Unsuccessful","The pre-qualification process was unsuccessful.", 
-,"complete","Complete","The pre-qualification process is complete.", 
+Code,Title_en,Description_en
+planned,Planned,"This pre-qualification has been proposed, but is not yet taking place."
+active,Active,A pre-qualification process is currently taking place.
+cancelled,Cancelled,The pre-qualification process has been cancelled.
+unsuccessful,Unsuccessful,The pre-qualification process was unsuccessful.
+complete,Complete,The pre-qualification process is complete.


### PR DESCRIPTION
open-contracting/standard-maintenance-scripts#6