### PR TITLE
Fix release tag enum

### DIFF
--- a/release-schema.json
+++ b/release-schema.json
@@ -32,7 +32,8 @@
           "shortlistUpdate"
         ]
       },
-      "codelist": "releaseTag.csv"
+      "codelist": "releaseTag.csv",
+      "openCodelist": false
     }
   },
   "definitions": {

--- a/release-schema.json
+++ b/release-schema.json
@@ -4,6 +4,35 @@
       "title": "Pre-qualification",
       "description": "The activities undertaken in order to qualify suppliers to participate in the tender.",
       "$ref": "#/definitions/PreQualification"
+    },
+    "tag": {
+      "items": {
+        "enum": [
+          "planning",
+          "planningUpdate",
+          "tender",
+          "tenderAmendment",
+          "tenderUpdate",
+          "tenderCancellation",
+          "award",
+          "awardUpdate",
+          "awardCancellation",
+          "contract",
+          "contractUpdate",
+          "contractAmendment",
+          "implementation",
+          "implementationUpdate",
+          "contractTermination",
+          "compiled",
+          "qualification",
+          "shortlist",
+          "qualificationUpdate",
+          "qualificationCancellation",
+          "qualificationAmendment",
+          "shortlistUpdate"
+        ]
+      },
+      "codelist": "releaseTag.csv"
     }
   },
   "definitions": {


### PR DESCRIPTION
Previously the additions to the csv were in this repository, whilst the changes to the enum were in the ppp extension repository, which was causing a test to make the PPP build fail.